### PR TITLE
Remove unused variables in `sdcard.c/h`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ dkms.conf
 
 # Python version file
 .python-version
+
+# VSCode:
+.vscode/

--- a/Core/Inc/sdcard.h
+++ b/Core/Inc/sdcard.h
@@ -40,8 +40,6 @@ void sdCardSave(FIL* file_obj);
 void sdCardClose(FIL* file_obj);
 
 extern FRESULT fres;
-extern uint16_t raw_temp;
 extern char log_path[];
-extern char buf[];
 
 #endif /* INC_SDCARD_H_ */

--- a/Core/Src/sdcard.c
+++ b/Core/Src/sdcard.c
@@ -10,7 +10,6 @@
 
 FATFS fs;
 char log_path[] = "/TEMPLOG.TXT";
-char buf[20];
 
 FRESULT sdCardInit(FIL* file_obj, char* path, size_t path_len) {
     FRESULT stat;


### PR DESCRIPTION
Might use this PR later for further tweaking the SD card. Essentially the write transactions are starving the CPU and not triggering the interrupts. After the buffer is in place I will check this again