### PR TITLE
imu fix

### DIFF
--- a/Core/Inc/firm_utils.h
+++ b/Core/Inc/firm_utils.h
@@ -17,3 +17,12 @@
  * @retval the signed 16-bit integer.
  */
 int16_t twos_complement_16(uint8_t msb, uint8_t lsb);
+
+/**
+ * @brief Turns a 20 bit value into a sign extended 20 bit value
+ *
+ * @param x unsigned 32 bit integer storing a 20 bit value
+ *
+ * @retval sign extended 20 bit value
+ */
+int32_t sign_extend_20bit(uint32_t val);

--- a/Core/Inc/firm_utils.h
+++ b/Core/Inc/firm_utils.h
@@ -19,10 +19,13 @@
 int16_t twos_complement_16(uint8_t msb, uint8_t lsb);
 
 /**
- * @brief Turns a 20 bit value into a sign extended 20 bit value
+ * @brief Converts an unsigned 20-bit value to a signed 32-bit integer by sign-extending the 19th bit.
  *
- * @param x unsigned 32 bit integer storing a 20 bit value
+ * This function takes an unsigned 32-bit integer containing a 20-bit value (bits 0–19)
+ * and returns a signed 32-bit integer, where the sign bit (bit 19) is extended to bits 20–31.
  *
- * @retval sign extended 20 bit value
+ * @param val Unsigned 32-bit integer storing a 20-bit value (bits 0–19).
+ *
+ * @retval Signed 32-bit integer with the value of the input, sign-extended from bit 19.
  */
 int32_t sign_extend_20bit(uint32_t val);

--- a/Core/Inc/firm_utils.h
+++ b/Core/Inc/firm_utils.h
@@ -19,7 +19,8 @@
 int16_t twos_complement_16(uint8_t msb, uint8_t lsb);
 
 /**
- * @brief Converts an unsigned 20-bit value to a signed 32-bit integer by sign-extending the 19th bit.
+ * @brief Converts an unsigned 20-bit value to a signed 32-bit integer by sign-extending the 19th
+ * bit.
  *
  * This function takes an unsigned 32-bit integer containing a 20-bit value (bits 0–19)
  * and returns a signed 32-bit integer, where the sign bit (bit 19) is extended to bits 20–31.

--- a/Core/Src/firm_utils.c
+++ b/Core/Src/firm_utils.c
@@ -8,3 +8,7 @@
 #include "firm_utils.h"
 
 int16_t twos_complement_16(uint8_t msb, uint8_t lsb) { return (int16_t)((msb << 8) | lsb); }
+
+int32_t sign_extend_20bit(uint32_t val) {
+    return (int32_t)(val << 12) >> 12;
+}

--- a/Core/Src/icm45686.c
+++ b/Core/Src/icm45686.c
@@ -117,23 +117,24 @@ int imu_read(SPI_HandleTypeDef* hspi, GPIO_TypeDef* cs_channel, uint16_t cs_pin,
     if (data_ready & 0x04) { // bit 2 is data_ready flag for UI channel
         // each packet from the fifo is 20 bytes
         uint8_t raw_data[20];
-        spi_read(hspi, cs_channel, cs_pin, 0x14, raw_data, 20);
-        uint32_t temp;
-        int32_t ax, ay, az, gx, gy, gz;
+        spi_read(hspi, cs_channel, cs_pin, fifo_data, raw_data, 20);
+
+        // refer to the datasheet section 6.1 "packet structure" for information on the packet
+        // structure to see which bytes of the FIFO packet go to which data points.
         // Accel X
-        temp = ((uint32_t)raw_data[1] << 12) | ((uint32_t)raw_data[2] << 4) | (raw_data[17] >> 4);
-        ax = sign_extend_20bit(temp);
+        uint32_t temp = ((uint32_t)raw_data[1] << 12) | ((uint32_t)raw_data[2] << 4) | (raw_data[17] >> 4);
+        int32_t ax = sign_extend_20bit(temp);
         // Accel Y
         temp = ((uint32_t)raw_data[3] << 12) | ((uint32_t)raw_data[4] << 4) | (raw_data[18] >> 4);
-        ay = sign_extend_20bit(temp);
+        int32_t ay = sign_extend_20bit(temp);
 
         // Accel Z
         temp = ((uint32_t)raw_data[5] << 12) | ((uint32_t)raw_data[6] << 4) | (raw_data[19] >> 4);
-        az = sign_extend_20bit(temp);
+        int32_t az = sign_extend_20bit(temp);
 
         // Gyro X
         temp = ((uint32_t)raw_data[7] << 12) | ((uint32_t)raw_data[8] << 4) | (raw_data[17] & 0x0F);
-        gx = sign_extend_20bit(temp);
+        int32_t gx = sign_extend_20bit(temp);
 
         // Gyro Y
         temp =
@@ -143,7 +144,7 @@ int imu_read(SPI_HandleTypeDef* hspi, GPIO_TypeDef* cs_channel, uint16_t cs_pin,
         // Gyro Z
         temp =
             ((uint32_t)raw_data[11] << 12) | ((uint32_t)raw_data[12] << 4) | (raw_data[19] & 0x0F);
-        gz = sign_extend_20bit(temp);
+        int32_t gz = sign_extend_20bit(temp);
 
         // TODO: determine whether the data should be logged before or after the scale factor
         // is applied.

--- a/Core/Src/icm45686.c
+++ b/Core/Src/icm45686.c
@@ -122,7 +122,8 @@ int imu_read(SPI_HandleTypeDef* hspi, GPIO_TypeDef* cs_channel, uint16_t cs_pin,
         // refer to the datasheet section 6.1 "packet structure" for information on the packet
         // structure to see which bytes of the FIFO packet go to which data points.
         // Accel X
-        uint32_t temp = ((uint32_t)raw_data[1] << 12) | ((uint32_t)raw_data[2] << 4) | (raw_data[17] >> 4);
+        uint32_t temp =
+            ((uint32_t)raw_data[1] << 12) | ((uint32_t)raw_data[2] << 4) | (raw_data[17] >> 4);
         int32_t ax = sign_extend_20bit(temp);
         // Accel Y
         temp = ((uint32_t)raw_data[3] << 12) | ((uint32_t)raw_data[4] << 4) | (raw_data[18] >> 4);

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -124,8 +124,9 @@ int main(void) {
 
     FRESULT res = sdCardInit(&file_obj, log_path, strlen(log_path));
     if (res) {
-        Error_Handler();
         serialPrintStr("bad init sd card");
+        Error_Handler();
+
     }
 
     // drive chip select pins high
@@ -135,12 +136,13 @@ int main(void) {
     HAL_GPIO_WritePin(GPIOB, GPIO_PIN_9, GPIO_PIN_SET); // imu pin
 
     HAL_Delay(5000); // purely for debug purposes, allows time to connect to USB serial terminal
-    if (bmp_init(&hspi2, GPIOC, GPIO_PIN_2)) {
-        Error_Handler();
-    }
+
 
     if (imu_init(&hspi2, GPIOB, GPIO_PIN_9)) {
         Error_Handler();
+    }
+    if (bmp_init(&hspi2, GPIOC, GPIO_PIN_2)) {
+            Error_Handler();
     }
 
     // Toggle LED:


### PR DESCRIPTION
corrects the imu to maybe have a 32g cap now. This must be done with FIFO cause it doesnt seem to work without it. The read operation takes about twice as long unfortunately, but we also get 20-bit data resolution instead of 16-bit. 